### PR TITLE
🐛 active_support must be explicitly required

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "active_support/tagged_logging"
-require "active_support/logger"
+require "active_support"
 
 module ActiveJob
   module Logging


### PR DESCRIPTION
- See: https://guides.rubyonrails.org/active_support_core_extensions.html
- Requirement of active_support/tagged_logging is removed because active_support autoloads it
